### PR TITLE
Validation error on tab view - property search based on validation tag

### DIFF
--- a/NUModules/NUModule.j
+++ b/NUModules/NUModule.j
@@ -2909,13 +2909,8 @@ NUModuleTabViewModeIcon                = 2;
             tabViewItem         = [tabViewPrototype tabViewItem],
             control             = [[tabViewItem view] subviewWithTag:aPropertyName recursive:YES];
 
-        if (!control)
-        {
-            control = [[tabViewItem view] subviewWithTag:@"validation_"+aPropertyName recursive:YES];
-        }
-        
         if (control)
-            return tabViewPrototype;    
+            return tabViewPrototype;
     }
 
     return nil;

--- a/NUModules/NUModule.j
+++ b/NUModules/NUModule.j
@@ -2909,8 +2909,13 @@ NUModuleTabViewModeIcon                = 2;
             tabViewItem         = [tabViewPrototype tabViewItem],
             control             = [[tabViewItem view] subviewWithTag:aPropertyName recursive:YES];
 
+        if (!control)
+        {
+            control = [[tabViewItem view] subviewWithTag:@"validation_"+aPropertyName recursive:YES];
+        }
+        
         if (control)
-            return tabViewPrototype;
+            return tabViewPrototype;    
     }
 
     return nil;

--- a/NUModules/NUModuleContext.j
+++ b/NUModules/NUModuleContext.j
@@ -538,7 +538,7 @@ var _isCPArrayControllerKind = function(object, keyPath)
 
                 [control bind:CPValueBinding toObject:_editedObject withKeyPath:keyPath options:opts];
             }
-            else
+            else if (![control isKindOfClass:CPView])
                 [CPException raise:CPInternalInconsistencyException reason:"NUModuleContext doesn't support binding for control class: " + [control class]];
         }
     }


### PR DESCRIPTION
Presently to identify the tab view corresponding to the property whose validation has failed, the search is based on `tag`
In case of an associator based property, `tag` is inapplicable on CPView corresponding to the associator.
As a work around, using tag `validation_propertyName` for search.