### PR TITLE
fetcher.currentResponseCount in place of array count to determine current page

### DIFF
--- a/NUModules/NUModule.j
+++ b/NUModules/NUModule.j
@@ -1432,7 +1432,7 @@ NUModuleTabViewModeIcon                = 2;
             fetcher        = [_currentParent valueForKeyPath:[context fetcherKeyPath]];
 
         _maxPossiblePage    = MAX(Math.ceil([fetcher currentTotalCount] / NUModuleRESTPageSize) - 1, 0);
-        _latestPageLoaded   = MAX(Math.ceil([[fetcher array] count] / NUModuleRESTPageSize) - 1, 0);
+        _latestPageLoaded   = MAX(Math.ceil([fetcher currentResponseCount] / NUModuleRESTPageSize) - 1, 0);
     }
     else
     {


### PR DESCRIPTION
Until now count of _contents was being used to determine current count, and this was being used to determine current page number fetched.
But this does not work in associators.
commit is set as false in NURESTConnection based on NUObjectsChooser.commitFetchedObjects.
Because of this, _contents will not be updated when commit is false.

Peer PR: https://github.com/nuagenetworks/objj-bambou/pull/4
Ticket: http://mvjira.mv.usa.alcatel.com/browse/VSD-22759